### PR TITLE
updated DPChat to check for connected status before attempting to sen…

### DIFF
--- a/petstore/petstoreapp/soulmachines-react-app/src/routes/DPChat.js
+++ b/petstore/petstoreapp/soulmachines-react-app/src/routes/DPChat.js
@@ -63,9 +63,11 @@ function DPChat({
 
   useEffect(() => {
     // send init event, since we will finish loading before we display the DP
-    setTimeout(() => {
-      dispatch(sendTextMessage({ text: '...' }));
-    }, 5000);
+    if (connected) {
+      setTimeout(() => {
+        dispatch(sendTextMessage({ text: '...' }));
+      }, 2500);
+    }
     // run resize once on mount, then add listener for future resize events
     handleResize();
     window.addEventListener('resize', handleResize);

--- a/petstore/petstoreapp/soulmachines-react-app/src/routes/Loading.js
+++ b/petstore/petstoreapp/soulmachines-react-app/src/routes/Loading.js
@@ -157,7 +157,11 @@ function Loading({
   };
   const history = useHistory();
   useEffect(() => {
-    if (skip === true && connected === true) history.push('/video');
+    if (skip === true && connected === true) {
+      setTimeout(() => {
+        history.push('/video');
+      }, 2500);
+    }
   }, [connected, skip]);
 
   return (


### PR DESCRIPTION
Discovered that the reason the DP was already talking was dude to the useEffect firing on reload before the redirect to the loading screen happened. This caused the dp to receive the '...' before the user had moved on to that page. I put in a check for "connected" status before sending that message, so that should be resolved.

I also split the timeout between the loading and dpchat pages to minimize the perceived awkwardness when the user needs to wait for the DP to respond to the '...'.
